### PR TITLE
Add missing dependency: librosa

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -12,3 +12,4 @@ pytest~=8.1.1
 requests~=2.31.0
 setproctitle~=1.3.3
 flwr_datasets~=0.3.0
+librosa~=0.11.0


### PR DESCRIPTION
Hello! While trying out the simulator, I encountered an error due to a missing dependency librosa, so I added it to the requirements.txt.